### PR TITLE
fix(module-names): Fix module name transformation

### DIFF
--- a/logger/compact-logger.js
+++ b/logger/compact-logger.js
@@ -75,7 +75,9 @@ module.exports = function CompactLogger() {
 
 				// Transform absolute paths into relative ones (to shorten the so so incredible long path)
 				if ( betterModuleName.indexOf( absoluteProjectPath ) !== -1 ) {
-					betterModuleName = betterModuleName.split( `${ absoluteProjectPath }\\` )[ 1 ];
+					betterModuleName = betterModuleName
+						.split( `${ absoluteProjectPath }` )[ 1 ] // Transform absolute path to relative one
+						.substring( 1 ); // Remove leading path slash
 				}
 
 				// Improve the path presentation further by enforcing style consistency and removing unnecessary details

--- a/logger/expanded-logger.js
+++ b/logger/expanded-logger.js
@@ -62,7 +62,9 @@ module.exports = function ExpandedLogger() {
 
 				// Transform absolute paths into relative ones (to shorten the so so incredible long path)
 				if ( betterModuleName.indexOf( absoluteProjectPath ) !== -1 ) {
-					betterModuleName = betterModuleName.split( `${ absoluteProjectPath }\\` )[ 1 ];
+					betterModuleName = betterModuleName
+						.split( `${ absoluteProjectPath }` )[ 1 ] // Transform absolute path to relative one
+						.substring( 1 ); // Remove leading path slash
 				}
 
 				// Improve the path presentation further by enforcing style consistency and removing unnecessary details

--- a/logger/minimal-logger.js
+++ b/logger/minimal-logger.js
@@ -66,7 +66,9 @@ module.exports = function MinimalLogger() {
 
 				// Transform absolute paths into relative ones (to shorten the so so incredible long path)
 				if ( betterModuleName.indexOf( absoluteProjectPath ) !== -1 ) {
-					betterModuleName = betterModuleName.split( `${ absoluteProjectPath }\\` )[ 1 ];
+					betterModuleName = betterModuleName
+						.split( `${ absoluteProjectPath }` )[ 1 ] // Transform absolute path to relative one
+						.substring( 1 ); // Remove leading path slash
 				}
 
 				// Improve the path presentation further by enforcing style consistency and removing unnecessary details


### PR DESCRIPTION
- Fix module name transformation breaking when the path contains slashes instead of backslashes

Closes #7.